### PR TITLE
fix(lib): fix crash that happens on android when currentTime < 0

### DIFF
--- a/lib/src/apivideo_player_overlay.dart
+++ b/lib/src/apivideo_player_overlay.dart
@@ -64,6 +64,7 @@ class _ApiVideoPlayerOverlayState extends State<ApiVideoPlayerOverlay>
       },
     );
   }
+
   bool _isPlaying = false;
   bool _didEnd = false;
 
@@ -323,10 +324,14 @@ class _ApiVideoPlayerOverlayState extends State<ApiVideoPlayerOverlay>
           children: [
             Expanded(
               child: Slider(
-                value: min(
-                  _currentTime.inMilliseconds,
-                  _duration.inMilliseconds,
-                ).toDouble(), // Ensure that the slider doesn't go over the duration
+                value: max(
+                    0,
+                    min(
+                      _currentTime.inMilliseconds,
+                      _duration.inMilliseconds,
+                    )).toDouble(),
+                // Ensure that the slider doesn't go over the duration or under 0.0
+                min: 0.0,
                 max: _duration.inMilliseconds.toDouble(),
                 activeColor: widget.theme.activeTimeSliderColor,
                 inactiveColor: widget.theme.inactiveTimeSliderColor,


### PR DESCRIPTION
Detected on Android. Might exist on iOS and Web.
Reproduce:
1/ Launch sample app
2/ Enter a bad video id
3/ Seek backward (with player example for example)

`currentTime` could be under `0.0` which leads to a crash of the slider